### PR TITLE
feed.xml 内の MP3 ファイルの URL を修正

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -28,7 +28,7 @@
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <description>{{ post.content | xml_escape }}</description>
         <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
-        <enclosure url="{{ site.url }}{{ post.id }}.mp3" length="{{ post.audio_file_size }}" type="audio/mp3"/>
+        <enclosure url="{{ site.url }}/{{ post.id | replace: '/', '-' | replace_first: '-', 'audio/' }}.mp3" length="{{ post.audio_file_size }}" type="audio/mp3"/>
         <itunes:author>{{ site.author }}</itunes:author>
         <itunes:subtitle>{{ post.description }}</itunes:subtitle>
         <itunes:duration>{{ post.duration }}</itunes:duration>


### PR DESCRIPTION
Jekyll における `post.id` は日付のハイフンの部分を `/` にしてしまうので、feed.xml の該当部分で

``` xml
<enclosure url="https://yatteikifm.github.io/2016/10/29/yatteiki-first.mp3" length="28010160" type="audio/mp3"/>
```

のような URI が生成されてしまいます。

この p-r のコミットのように replace でなんとかやることもできますが、ちょっとひどい感じもするので、_posts 下の Markdown のメタデータ部分に `audio_file_path` のようなフィールドを追加するみたいな感じでやっていくなどするとまだましかなという気持ちです 💪 
