### PR TITLE
Normalize voice volume with audacity compressor effect

### DIFF
--- a/_posts/2016-10-30-yatteiki-first.md
+++ b/_posts/2016-10-30-yatteiki-first.md
@@ -10,10 +10,10 @@ actors:
     name: r7kamura
     url: https://twitter.com/r7kamura
 audio_file_path: /audio/2016-10-30-yatteiki-first.mp3
-audio_file_size: 28010160
+audio_file_size: 25376679
 date: 2016-10-30 00:00:00 +0900
 description: soramugi、9m、r7kamura の3人でやっていき方について話しました。
-duration: "58:21"
+duration: "58:20"
 layout: article
 title: "1. やっていきはじめ"
 ---


### PR DESCRIPTION
Audacityのcompressor effectをかけてmp3を再buildしました。
- 元音源ではr7kamuraの声が-35dBから-20dB程度、他2人が-6dB程度だった
- -20dB以下の音に1:7 (かなり強め) のrateで強調
- -40dB以下の音はノイズ扱い
