### PR TITLE
Use the same description style in all episodes

### DIFF
--- a/_posts/2016-10-29-1.md
+++ b/_posts/2016-10-29-1.md
@@ -12,7 +12,7 @@ actors:
 audio_file_path: /audio/1.mp3
 audio_file_size: 28003055
 date: 2016-10-30 00:00:00 +0900
-description: soramugi、9m、r7kamura の3人でやっていき方について話しました。
+description: soramugiと9mとr7kamuraの3人で、やっていき方について話しました。
 duration: 58:20
 layout: article
 title: 1. やっていきはじめ

--- a/_posts/2016-11-02-2.md
+++ b/_posts/2016-11-02-2.md
@@ -9,7 +9,7 @@ actors:
 audio_file_path: /audio/2.mp3
 audio_file_size: 33120338
 date: 2016-11-02 00:00:00 +0900
-description: 伊藤さんと初学者の悩みを話しました。
+description: itopoidとsoramugiの2人で、初学者の悩みについて話しました。
 duration: 1:09:00
 layout: article
 title: 2. 聖地巡礼のやっていき


### PR DESCRIPTION
## 変更の目的

説明文のフォーマットを統一して、リズムをつくりたい。

## なぜこのタイミングで変更するのか

2話が追加されたことで、1話と2話との共通フォーマットという視点が生まれた。

## 提案概要

説明文をこういうフォーマットに統一してみた方が良さそう。

```
{name1}と{name2}[と{name3}]のN人で、{description}について話しました。
```

## 思想的なところ

### 名前

- name1, name2などにはインターネットネームを利用する方が良い
- Starringの箇所ではそういう名前で紹介しているので対応付けという意味でも

### 敬称略

- Aさん vs. Bさん での対話という構図
- AとBの2人で一緒に発信

を比較すると、後者でのやっていきのスタンスを取りたい。

### ...について話しました

テック系Podcastの紹介文の共通フォーマットがこういう感じ (主観)。

## 語彙

### 説明文とは

記事に対する1行説明のところ。Podcastの各話の内容部分などにも利用される。