### PR TITLE
Add post.description to <description> in feed.xml

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -26,7 +26,12 @@
         <title>{{ post.title | xml_escape }}</title>
         <link>{{ site.url }}{{ post.url }}</link>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <description>{{ post.content | xml_escape }}</description>
+        <description>
+          &lt;p&gt;
+            {{ post.description | xml_escape }}
+          &lt;/p&gt;
+          {{ post.content | xml_escape }}
+        </description>
         <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
         <enclosure url="{{ site.url }}{{ post.audio_file_path }}" length="{{ post.audio_file_size }}" type="audio/mp3"/>
         <itunes:author>{{ site.author }}</itunes:author>


### PR DESCRIPTION
`<itunes:subtitle>`タグにも`post.description`が含まれていますが、この要素に対応していないクライアントでは関連リンクのみが表示され、エピソードのあらましや話者は確認できません。これらの情報は一般的な`<description>`タグにも追加されていたほうが便利なように思います。