### PR TITLE
Update header contents

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,16 +7,10 @@
     </h1>
     <nav class="header-navigation">
       <a href="/" class="header-navigation-element">
-        ラジオ
+        音声
       </a>
       <a href="/tv" class="header-navigation-element">
         動画
-      </a>
-      <a href="https://medium.com/yatteiki" class="header-navigation-element" target="_blank">
-        ブログ
-      </a>
-      <a href="https://yatteiki.theshop.jp" class="header-navigation-element" target="_blank">
-        ショップ
       </a>
     </nav>
   </div>


### PR DESCRIPTION
## 背景

ヘッダーのコンテンツが古くなっていることもあり、内容を見直すことにしました。

![image](https://user-images.githubusercontent.com/111689/96392494-3ba20400-11f7-11eb-9f7f-88e1c72877b7.png)

ブログは現状更新していない (上にr7kamuraがmediumから個人サイトに移行した余波をまともに喰らって410でアクセスできないという最悪の条件で本当に申し訳ない) し、ショップは現状休止中なので、取り除くことに。

カタカナのものが2つ減ると、ラジオ・動画という対比の違和感が浮き彫りになってしまったので、音声・動画に変更してみることにしました。この辺はまた後にすぐ変えるかもしれません。

![image](https://user-images.githubusercontent.com/111689/96392431-ff6ea380-11f6-11eb-9328-434c887799a2.png)
