### PR TITLE
Inert six-digit auth code to migrate Podcast Apple ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -89,7 +89,7 @@ exclude:
   - vendor
 hashtag: yatteikifm
 itunes_podcast_url: https://itunes.apple.com/jp/podcast/yatteiki.fm/id1170904671?mt=2
-keywords: tech,technology,yatteiki,programming,mobile,web,development,developer,software
+keywords: tech,technology,yatteiki,programming,mobile,web,development,developer,software,553695
 language: ja
 markdown: kramdown
 permalink: /episode/:title


### PR DESCRIPTION
We'll migrate it from soramugi's one to yatteikifm@gmail.com's one.

I'm working on the following information sent to us by Apple support:

```
1. Insert the six-digit authorization code “553695” in the <itunes:keywords> or <copyright> tag.
2. Verify that your Apple ID is activated.
```